### PR TITLE
Sort reflection keys to ensure signed payloads are the same for transactions that require multiple signatures

### DIFF
--- a/ecc/privkey_gm.go
+++ b/ecc/privkey_gm.go
@@ -43,14 +43,6 @@ func (k *innerGMPrivateKey) sign(hash []byte) (out Signature, err error) {
 
 	return Signature{Curve: CurveGM, Content: outBytes, inner: &innerGMSignature{}}, nil
 
-	/*	compactSig, err := k.privKey.SignCanonical(btcec.S256(), hash)
-
-		if err != nil {
-			return out, fmt.Errorf("canonical, %s", err)
-		}
-
-		return Signature{Curve: CurveGM, Content: compactSig, inner: &innerGMSignature{}}, nil
-	*/
 }
 func (k *innerGMPrivateKey) string() string {
 	return "PVT_GM_" + EncodeWifSM2PrivateKey(0x80, k.privKey.D.Bytes(), true)

--- a/signer.go
+++ b/signer.go
@@ -139,7 +139,6 @@ func (b *KeyBag) ImportPrivateKeyFromEnv(ctx context.Context, envVarName string)
 	return err
 }
 
-
 func (b *KeyBag) SignDigest(digest []byte, requiredKey ecc.PublicKey) (ecc.Signature, error) {
 
 	privateKey := b.keyMap()[requiredKey.String()]


### PR DESCRIPTION
Sort reflection keys to ensure signed payloads are the same for transactions that require multiple signatures